### PR TITLE
Fix/GitHub provider

### DIFF
--- a/src/auth/core/oauth/base.ts
+++ b/src/auth/core/oauth/base.ts
@@ -127,8 +127,10 @@ export class OAuthClient<T> {
             })
 
           if (!success) throw new InvalidUserError(error)
-          const email = data.find((email) => email.primary && email.verified)
-          if (email == null) throw new Error("No email found") // Can create a custom error for this
+          const email =
+            data.find((email) => email.primary && email.verified) ??
+            data.find((email) => email.primary) ??
+            data[0]
           rawData.email = email.email
         }
 

--- a/src/auth/core/oauth/base.ts
+++ b/src/auth/core/oauth/base.ts
@@ -95,8 +95,43 @@ export class OAuthClient<T> {
         Authorization: `${tokenType} ${accessToken}`,
       },
     })
-      .then(res => res.json())
-      .then(rawData => {
+      .then((res) => res.json())
+      .then(async (rawData) => {
+        // For the GitHub provider, /user endpoint only returns public email
+        // User preferably might hide or not pick a public email
+        // so we need to fetch the emails from the /user/emails endpoint (needs user:email scope)
+        // Reference: https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user
+        if (this.provider === "github" && !rawData.email) {
+          const { data, success, error } = await fetch(
+            "https://api.github.com/user/emails",
+            {
+              headers: {
+                Authorization: `${tokenType} ${accessToken}`,
+                Accept: "application/vnd.github+json",
+              },
+            }
+          )
+            .then((res) => res.json())
+            .then((rawData) => {
+              // GitHub returns an array of objects with email, primary, verified and visibility (nullable string) properties
+              // If we reach that point, we can assume the user has a private email, so no need to check visibility
+              return z
+                .array(
+                  z.object({
+                    email: z.string().email(),
+                    primary: z.boolean(),
+                    verified: z.boolean(),
+                  })
+                )
+                .safeParse(rawData)
+            })
+
+          if (!success) throw new InvalidUserError(error)
+          const email = data.find((email) => email.primary && email.verified)
+          if (email == null) throw new Error("No email found") // Can create a custom error for this
+          rawData.email = email.email
+        }
+
         const { data, success, error } = this.userInfo.schema.safeParse(rawData)
         if (!success) throw new InvalidUserError(error)
 

--- a/src/auth/core/oauth/base.ts
+++ b/src/auth/core/oauth/base.ts
@@ -82,7 +82,7 @@ export class OAuthClient<T> {
   }
 
   async fetchUser(code: string, state: string, cookies: Pick<Cookies, "get">) {
-    const isValidState = await validateState(state, cookies)
+    const isValidState = validateState(state, cookies)
     if (!isValidState) throw new InvalidStateError()
 
     const { accessToken, tokenType } = await this.fetchToken(


### PR DESCRIPTION
This pull request includes updates to the `OAuthClient` class to improve the handling of user email retrieval for GitHub OAuth. Changes include removing unnecessary asynchronous validation, adding logic to fetch user emails from GitHub's `/user/emails` endpoint, and updating the code to handle the fetched email data.

### Improvements to GitHub OAuth email handling:

* `src/auth/core/oauth/base.ts`: Removed unnecessary asynchronous call to `validateState` method, simplifying the validation process.
* `src/auth/core/oauth/base.ts`: Added logic to fetch user emails from GitHub's `/user/emails` endpoint if the public email is not available in the initial response. This ensures that private emails are also considered, improving the reliability of the email retrieval process.